### PR TITLE
Improved behavior when using ANSI characters in filenames

### DIFF
--- a/source/input/avs.cpp
+++ b/source/input/avs.cpp
@@ -77,6 +77,9 @@ void AVSInput::info_avs()
 
 void AVSInput::openfile(InputFileInfo& info)
 {
+    wchar_t real_filename_wchar[MAX_PATH * 4];
+    MultiByteToWideChar(CP_UTF8, 0, real_filename, -1, real_filename_wchar, 1024);
+    WideCharToMultiByte(CP_THREAD_ACP, 0, real_filename_wchar, -1, real_filename, 1024, NULL, NULL);
     AVS_Value res = h->func.avs_invoke(h->env, "Import", avs_new_value_string(real_filename), NULL);
     FAIL_IF_ERROR(avs_is_error(res), "Error loading file: %s\n", avs_as_string(res));
     FAIL_IF_ERROR(!avs_is_clip(res), "File didn't return a video clip\n");

--- a/source/output/mp4.cpp
+++ b/source/output/mp4.cpp
@@ -133,7 +133,7 @@ void MP4Output::closeFile(int64_t largest_pts, int64_t second_largest_pts)
 
 int MP4Output::openFile(const char *psz_filename)
 {
-    FILE *fh = fopen(psz_filename, "wb");
+    FILE *fh =  x265_fopen(psz_filename, "wb");
     MP4_FAIL_IF_ERR(!fh, "cannot open output file `%s'.\n", psz_filename);
     fclose(fh);
 


### PR DESCRIPTION
This patch will allow you to properly load AviSynth Scripts that contain ANSI characters in their filenames.
Also, if the file name contains ANSI characters when outputting mp4, garbled empty files will not be output.